### PR TITLE
Reorganize Mech-building a bit

### DIFF
--- a/_data/navlinks.json
+++ b/_data/navlinks.json
@@ -19,8 +19,8 @@
     "Mech Building" :
     {
       "Overview": "/rules/build-overview/",
-      "Components": "/rules/component-types/",
       "Planning": "/rules/build-planning/",
+      "Component Types": "/rules/component-types/",
       "Placing Components": "/rules/placing-components/",
       "Calculations": "/rules/build-calculations/",
       "Validating": "/rules/build-validating/"

--- a/custom-variables.css
+++ b/custom-variables.css
@@ -92,12 +92,6 @@ li {
     list-style-position: outside;
 }
 
-blockquote > p {
-    padding-left: 1rem;
-    border-left: 2px solid var(--dark-color);
-    background-color: var(--gray-color-light);
-}
-
 .modal-title {
     color: #ffffff;
 }

--- a/rules/mech-building/components.md
+++ b/rules/mech-building/components.md
@@ -9,6 +9,7 @@ tags: rules_page
 A mech is exactly the sum of its {% keyword 'Parts' glossary %}. This page explains the different {% keyword 'Part Type' glossary %}s as well as what their accompanying stats and traits represent. 
 
 > Looking for somewhere to view component stats? Check out [MechDB]({{site.url}}/mechdb/viewer)!
+{.text-muted}
 
 <!-- TODO: Table of Contents -->
 

--- a/rules/mech-building/overview.md
+++ b/rules/mech-building/overview.md
@@ -19,3 +19,31 @@ Most infrastructure components can be grouped into "Subsystems". These groups of
 - Power Subsystem: The power subsystem components are constrained by fuel type
 
 There are also a few things to note about the cabin. The cabin and the frame are the only two components which you can have strictly one of each per mech. The cabin is the ultimate weakpoint of your mech, and if it is destroyed, you die (see [Combat]({{ site.url }}/rules/combat)).
+
+### Step by step Guide to Building a Mech
+
+1. Develop a vision for your mechaneer and mech
+    - Come up with a name and background for your mechaneer
+    - Decide what you want to focus your mech on (combat, field repairs, science, etc.)
+2. Choose a Frame
+    - Smaller mechs are faster and often don't need auxiliary cooling
+    - Larger mechs have much more firepower
+3. Choose your mech's main weapons and equipment
+    - Find attachments that fit your vision
+    - Choose a power type that lets you get most of the attachments you want
+    - Don't worry about filling all your slots here, just pick a couple must-haves
+4. Add the control subsystem
+    - Choose a mainframe that provides enough processing for the components you've selected so far, plus a bit extra to spare
+    - Choose a cabin compatible with your mainframe's software
+5. Add the power subsystem
+    - Choose a power plant that provides enough power for the components you've selected so far, plus a bit extra to spare
+    - Choose a fuel tank for your power plant
+6. Check whether you need to add a cooler
+    - If you just barely have enough excess cooling to use your attachments at this point, you probably need to add a cooler
+7. Add more weapons and equipment
+    - Fill in remaining slots in your mech with a few more attachments
+8. Add Modules to your Mainframe
+    - Select modules that synergize with your mech's capabilities
+8. Check your resources and rebalance if needed
+    - Compute Available, Used, and Excess resources for Power, Processing, and Cooling
+    - If you don't have enough excess resources, consider upgrading infrastructure components or using less chonky weapons and equipment

--- a/rules/mech-building/planning.md
+++ b/rules/mech-building/planning.md
@@ -74,31 +74,3 @@ Some fuel types are much more energy-dense than others, which means that mechs u
 {.table}
 
 Depending on how much power your mech uses, you may need to consider a larger fuel tank or even a different fuel type. 
-
-### Step by step Mech-Building Outline
-
-1. Develop a vision for your mechaneer and mech
-    - Come up with a name and background for your mechaneer
-    - Decide what you want to focus your mech on (combat, field repairs, science, etc.)
-2. Choose a Frame
-    - Smaller mechs are faster and often don't need auxiliary cooling
-    - Larger mechs have much more firepower
-3. Choose your mech's main weapons and equipment
-    - Find attachments that fit your vision
-    - Choose a power type that lets you get most of the attachments you want
-    - Don't worry about filling all your slots here, just pick a couple must-haves
-4. Add the control subsystem
-    - Choose a mainframe that provides enough processing for the components you've selected so far, plus a bit extra to spare
-    - Choose a cabin compatible with your mainframe's software
-5. Add the power subsystem
-    - Choose a power plant that provides enough power for the components you've selected so far, plus a bit extra to spare
-    - Choose a fuel tank for your power plant
-6. Check whether you need to add a cooler
-    - If you just barely have enough excess cooling to use your attachments at this point, you probably need to add a cooler
-7. Add more weapons and equipment
-    - Fill in remaining slots in your mech with a few more attachments
-8. Add Modules to your Mainframe
-    - Select modules that synergize with your mech's capabilities
-8. Check your resources and rebalance if needed
-    - Compute Available, Used, and Excess resources for Power, Processing, and Cooling
-    - If you don't have enough excess resources, consider upgrading infrastructure components or using less chonky weapons and equipment


### PR DESCRIPTION
- Move components page to after planning in the navlinks
- Relocate the mech-building outline to the overview page
- Fix some silly styling that broke dark mode blockquotes